### PR TITLE
Fix typo on options page

### DIFF
--- a/pages/options.html
+++ b/pages/options.html
@@ -59,7 +59,7 @@
                 <label class="browser-style browser-style-label"><input type="checkbox" id="download" checked><label for="download"></label> Play sound for finished downloads while browser is in the background</label>
             </p>
             <p class="subsection">
-                <label class="browser-style browser-style-label"><input type="checkbox" id="downloadalways"><label for="downloadalways"></label> Alwas play a sound when a download finishes</label>
+                <label class="browser-style browser-style-label"><input type="checkbox" id="downloadalways"><label for="downloadalways"></label> Always play a sound when a download finishes</label>
             </p>
         </section>
     </body>


### PR DESCRIPTION
Corrects "Alwas" to "Always" under the _Downloads_ section of the options page.